### PR TITLE
Add multilang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,7 @@
 
 ## Features
 
-You can find the defintion of words using `linguee <query>` and it opens the browser when you hit enter. So far you can only find the definitions in:
-
-  - English -> Brazilian Portuguese
-  - Brazilian Portuguese -> English
-
-I'm working to add definitions in the other languages.
+You can find the defintion of words using `linguee <query>` and it opens the browser when you hit enter. You can change the default languages in the preferences.
 
 ## Installation
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,6 @@ class LingueeExtension(Extension):
         super(LingueeExtension, self).__init__()
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
 
-
 class KeywordQueryEventListener(EventListener):
 
     def on_event(self, event, extension):
@@ -33,7 +32,7 @@ class KeywordQueryEventListener(EventListener):
                     name='Define words on Linguee',
                     description='Define words "{}".'.format(event.get_argument()),
                     on_enter=OpenUrlAction(
-                        'https://www.linguee.com/english-portuguese/search?{}'.format(urlencode({ 'source': 'auto', 'query': event.get_argument() }))
+                        'https://www.linguee.com/' + extension.preferences["lang0"] + "-" + extension.preferences["lang1"] + '/search?{}'.format(urlencode({ 'source': 'auto', 'query': event.get_argument() }))
                     )
                 )
             )

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,20 @@
       "name": "Linguee",
       "description": "Define of words",
       "default_value": "linguee"
+    },
+    {
+      "id": "lang0",
+      "type": "input",
+      "name": "First languange",
+      "description": "First languange to translate to / from",
+      "default_value": "portuguese"
+    },
+    {
+      "id": "lang1",
+      "type": "input",
+      "name": "Second language",
+      "description": "Second languange to translate to / from",
+      "default_value": "english"
     }
   ]
 }


### PR DESCRIPTION
Hi,

this will address #1. Right now this solution is pretty simple. 

I could think of a further improvement to be able to define the languages while typing in the search bar like `linguee <lang0> <lang1> <word>`. What do you think?

Best,
mat1010