### PR TITLE
Migrate plugin to ulauncher v2 API

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import logging
 
 from ulauncher.api.client.Extension import Extension
@@ -11,7 +11,7 @@ from ulauncher.api.shared.action.OpenUrlAction import OpenUrlAction
 LOGGER = logging.getLogger(__name__)
 
 def urlencode(q):
-    return urllib.urlencode(q)
+    return urllib.parse.urlencode(q)
 
 class LingueeExtension(Extension):
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "2",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "Linguee",
   "description": "Definition of words with a simple keyword",
   "developer_name": "Tiago Celestino",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "python2" },
+  { "required_api_version": "^2.0.0", "commit": "master" }
+]


### PR DESCRIPTION
This change is to address #8  and support the latest ulauncher API version